### PR TITLE
[tiny fix] Fix typo breaking sorting by mooches

### DIFF
--- a/ui/src/app/components/chaos-table/chaos-table.component.ts
+++ b/ui/src/app/components/chaos-table/chaos-table.component.ts
@@ -34,7 +34,7 @@ export class ChaosTableComponent implements OnInit {
                         case 'DateLeft': return new Date(item.DateLeft);
                         case 'TotalTime': return +item.TotalTime;
                         case 'TrumpTime': return +item.TrumpTime;
-                        case 'MootchesTime': return +item.MoochesTime;
+                        case 'MoochesTime': return +item.MoochesTime;
                         default: return item[property];
                     }
                 };


### PR DESCRIPTION
There is a typo in Mooches causing it to default to string comparison and sort incorrectly.